### PR TITLE
Allow bytestring 0.12

### DIFF
--- a/attoparsec-time.cabal
+++ b/attoparsec-time.cabal
@@ -1,5 +1,5 @@
 name: attoparsec-time
-version: 1.0.3
+version: 1.0.4
 synopsis: Attoparsec parsers of time
 description: A collection of Attoparsec parsers for the \"time\" library
 category: Attoparsec, Parsers, Time
@@ -31,6 +31,6 @@ library
   build-depends:
     attoparsec >=0.13 && <0.15,
     base >=4.9 && <5,
-    bytestring >=0.10 && <0.12,
+    bytestring >=0.10 && <0.13,
     text >=1 && <3,
     time >=1.4 && <2


### PR DESCRIPTION
Hello,

Bytestring 0.12 has been released recently. This PR adds support for it.

You can check that `attoparsec-time` builds appropriately on master already using the following command:

```bash
cabal build --constraint="bytestring > 0.11" --allow-newer=bytestring
```

I've taken the liberty of incrementing the version number, but this could also be done with a simple Hackage revision